### PR TITLE
Disable clear option for version selection in AddOrUpdate component

### DIFF
--- a/src/pages/work/info/add-or-update/index.tsx
+++ b/src/pages/work/info/add-or-update/index.tsx
@@ -266,6 +266,7 @@ const AddOrUpdate = () => {
 						{ label: 'Version 2', value: 2 },
 					].find((item) => item.value === version)}
 					onChange={(e: any) => setVersion(Number(e?.value))}
+					isClearable={false}
 				/>
 			</div>
 			<Header />


### PR DESCRIPTION
Prevent users from clearing the version selection in the AddOrUpdate component to ensure a valid version is always selected.