### PR TITLE
Fix header label for brand column in challan entry

### DIFF
--- a/src/pages/delivery/_config/columns/index.tsx
+++ b/src/pages/delivery/_config/columns/index.tsx
@@ -118,7 +118,7 @@ export const challanEntryColumns = (): ColumnDef<IChallanEntryTableData>[] => [
 	},
 	{
 		accessorKey: 'brand_name',
-		header: 'Model',
+		header: 'Brand',
 		enableColumnFilter: false,
 	},
 	{


### PR DESCRIPTION
Correct the header label from 'Model' to 'Brand' in the challan entry columns.