### PR TITLE
Transfer Reparing Item in Order deatails and repaing Index page

### DIFF
--- a/src/pages/delivery/_config/columns/index.tsx
+++ b/src/pages/delivery/_config/columns/index.tsx
@@ -41,7 +41,12 @@ export const challanColumns = (
 ): ColumnDef<IChallanTableData>[] => [
 	{
 		accessorKey: 'is_delivery_complete',
-		header: 'Delivery Complete',
+		header: () => (
+			<>
+				Delivery <br />
+				Complete
+			</>
+		),
 		enableColumnFilter: false,
 		cell: (info) => (
 			<Switch

--- a/src/pages/store/_config/columns/index.tsx
+++ b/src/pages/store/_config/columns/index.tsx
@@ -29,6 +29,7 @@ import {
 	ITransferTableData,
 	IVendorTableData,
 	IWarehouseFetch,
+	IWarehouseKey,
 	IWarehouseTableData,
 } from './columns.type';
 import { getWarehouseAndBranch } from './utils';
@@ -169,300 +170,115 @@ export const productColumns = ({
 	handleOrderAgainstWarehouse10Trx: (row: Row<any>) => void;
 	handleOrderAgainstWarehouse11Trx: (row: Row<any>) => void;
 	handleOrderAgainstWarehouse12Trx: (row: Row<any>) => void;
-}): ColumnDef<IProductTableData>[] => [
-	{
-		accessorKey: 'is_maintaining_stock',
-		header: () => (
-			<>
-				Maintain <br />
-				Stock
-			</>
-		),
-		enableColumnFilter: false,
-		size: 90,
-		cell: (info) => {
-			return <StatusButton value={info.getValue() as boolean} />;
+}): ColumnDef<IProductTableData>[] => {
+	const columns: ColumnDef<IProductTableData>[] = [
+		{
+			accessorKey: 'is_maintaining_stock',
+			header: () => (
+				<>
+					Maintain <br />
+					Stock
+				</>
+			),
+			enableColumnFilter: false,
+			size: 90,
+			cell: (info) => {
+				return <StatusButton value={info.getValue() as boolean} />;
+			},
 		},
-	},
-	{
-		accessorKey: 'name',
-		header: 'Name',
-		enableColumnFilter: false,
-	},
-	{
-		accessorKey: 'category_name',
-		header: 'Category',
-		enableColumnFilter: false,
-	},
-	{
-		accessorKey: 'model_name',
-		header: 'Model',
-		enableColumnFilter: false,
-	},
-	{
-		accessorKey: 'size_name',
-		header: 'Size',
-		enableColumnFilter: false,
-	},
-	{
-		accessorKey: 'warranty_days',
-		header: 'Warranty Days',
-		enableColumnFilter: false,
-	},
-	{
-		accessorKey: 'service_warranty_days',
-		header: 'Service Warranty',
-		enableColumnFilter: false,
-	},
-	{
-		accessorKey: 'type',
-		header: 'Type',
-		enableColumnFilter: false,
-	},
-	{
-		id: 'action_trx',
-		header: () => (
-			<>
-				Internal <br />
-				Transfer
-			</>
-		),
-		cell: (info) => <Transfer onClick={() => handleAgainstTrx(info.row)} />,
-		size: 40,
-		meta: {
-			hidden: !actionTrxAccess,
-			disableFullFilter: true,
+		{
+			accessorKey: 'name',
+			header: 'Name',
+			enableColumnFilter: false,
 		},
-	},
-	{
-		accessorKey: 'warehouse_1',
-		header: () => {
-			const [warehouse_name, branch_name] = getWarehouseAndBranch(warehouse, 'warehouse_1');
-			return <Location branch_name={branch_name?.slice(0, -1)} warehouse_name={warehouse_name} />;
+		{
+			accessorKey: 'category_name',
+			header: 'Category',
+			enableColumnFilter: false,
 		},
-		enableColumnFilter: false,
-		cell: (info) => {
-			return (
-				<div className='flex items-center gap-2'>
-					<Transfer
-						onClick={() => handleOrderAgainstWarehouse1Trx(info.row)}
-						disabled={!actionOrderAgainstTrxAccess}
-					/>
-					<span>{info.getValue() as string}</span>
-				</div>
-			);
+		{
+			accessorKey: 'model_name',
+			header: 'Model',
+			enableColumnFilter: false,
 		},
-	},
-	{
-		accessorKey: 'warehouse_2',
-		header: () => {
-			const [warehouse_name, branch_name] = getWarehouseAndBranch(warehouse, 'warehouse_2');
-			return <Location branch_name={branch_name?.slice(0, -1)} warehouse_name={warehouse_name} />;
+		{
+			accessorKey: 'size_name',
+			header: 'Size',
+			enableColumnFilter: false,
 		},
-		enableColumnFilter: false,
-		cell: (info) => {
-			return (
-				<div className='flex items-center gap-2'>
-					<Transfer
-						onClick={() => handleOrderAgainstWarehouse2Trx(info.row)}
-						disabled={!actionOrderAgainstTrxAccess}
-					/>
-					<span>{info.getValue() as string}</span>
-				</div>
-			);
+		{
+			accessorKey: 'warranty_days',
+			header: 'Warranty Days',
+			enableColumnFilter: false,
 		},
-	},
-	{
-		accessorKey: 'warehouse_3',
-		header: () => {
-			const [warehouse_name, branch_name] = getWarehouseAndBranch(warehouse, 'warehouse_3');
-			return <Location branch_name={branch_name?.slice(0, -1)} warehouse_name={warehouse_name} />;
+		{
+			accessorKey: 'service_warranty_days',
+			header: 'Service Warranty',
+			enableColumnFilter: false,
 		},
-		enableColumnFilter: false,
-		cell: (info) => {
-			return (
-				<div className='flex items-center gap-2'>
-					<Transfer
-						onClick={() => handleOrderAgainstWarehouse3Trx(info.row)}
-						disabled={!actionOrderAgainstTrxAccess}
-					/>
-					<span>{info.getValue() as string}</span>
-				</div>
-			);
+		{
+			accessorKey: 'type',
+			header: 'Type',
+			enableColumnFilter: false,
 		},
-	},
-	{
-		accessorKey: 'warehouse_4',
-		header: () => {
-			const [warehouse_name, branch_name] = getWarehouseAndBranch(warehouse, 'warehouse_4');
-			return <Location branch_name={branch_name?.slice(0, -1)} warehouse_name={warehouse_name} />;
+		{
+			id: 'action_trx',
+			header: () => (
+				<>
+					Internal <br />
+					Transfer
+				</>
+			),
+			cell: (info) => <Transfer onClick={() => handleAgainstTrx(info.row)} />,
+			size: 40,
+			meta: {
+				hidden: !actionTrxAccess,
+				disableFullFilter: true,
+			},
 		},
-		enableColumnFilter: false,
-		cell: (info) => {
-			return (
-				<div className='flex items-center gap-2'>
-					<Transfer
-						onClick={() => handleOrderAgainstWarehouse4Trx(info.row)}
-						disabled={!actionOrderAgainstTrxAccess}
-					/>
-					<span>{info.getValue() as string}</span>
-				</div>
-			);
-		},
-	},
-	{
-		accessorKey: 'warehouse_5',
-		header: () => {
-			const [warehouse_name, branch_name] = getWarehouseAndBranch(warehouse, 'warehouse_5');
-			return <Location branch_name={branch_name?.slice(0, -1)} warehouse_name={warehouse_name} />;
-		},
-		enableColumnFilter: false,
-		cell: (info) => {
-			return (
-				<div className='flex items-center gap-2'>
-					<Transfer
-						onClick={() => handleOrderAgainstWarehouse5Trx(info.row)}
-						disabled={!actionOrderAgainstTrxAccess}
-					/>
-					<span>{info.getValue() as string}</span>
-				</div>
-			);
-		},
-	},
-	{
-		accessorKey: 'warehouse_6',
-		header: () => {
-			const [warehouse_name, branch_name] = getWarehouseAndBranch(warehouse, 'warehouse_6');
-			return <Location branch_name={branch_name?.slice(0, -1)} warehouse_name={warehouse_name} />;
-		},
-		enableColumnFilter: false,
-		cell: (info) => {
-			return (
-				<div className='flex items-center gap-2'>
-					<Transfer
-						onClick={() => handleOrderAgainstWarehouse6Trx(info.row)}
-						disabled={!actionOrderAgainstTrxAccess}
-					/>
-					<span>{info.getValue() as string}</span>
-				</div>
-			);
-		},
-	},
-	{
-		accessorKey: 'warehouse_7',
-		header: () => {
-			const [warehouse_name, branch_name] = getWarehouseAndBranch(warehouse, 'warehouse_7');
-			return <Location branch_name={branch_name?.slice(0, -1)} warehouse_name={warehouse_name} />;
-		},
-		enableColumnFilter: false,
-		cell: (info) => {
-			return (
-				<div className='flex items-center gap-2'>
-					<Transfer
-						onClick={() => handleOrderAgainstWarehouse7Trx(info.row)}
-						disabled={!actionOrderAgainstTrxAccess}
-					/>
-					<span>{info.getValue() as string}</span>
-				</div>
-			);
-		},
-	},
-	{
-		accessorKey: 'warehouse_8',
-		header: () => {
-			const [warehouse_name, branch_name] = getWarehouseAndBranch(warehouse, 'warehouse_8');
-			return <Location branch_name={branch_name?.slice(0, -1)} warehouse_name={warehouse_name} />;
-		},
-		enableColumnFilter: false,
-		cell: (info) => {
-			return (
-				<div className='flex items-center gap-2'>
-					<Transfer
-						onClick={() => handleOrderAgainstWarehouse8Trx(info.row)}
-						disabled={!actionOrderAgainstTrxAccess}
-					/>
-					<span>{info.getValue() as string}</span>
-				</div>
-			);
-		},
-	},
-	{
-		accessorKey: 'warehouse_9',
-		header: () => {
-			const [warehouse_name, branch_name] = getWarehouseAndBranch(warehouse, 'warehouse_9');
-			return <Location branch_name={branch_name?.slice(0, -1)} warehouse_name={warehouse_name} />;
-		},
-		enableColumnFilter: false,
-		cell: (info) => {
-			return (
-				<div className='flex items-center gap-2'>
-					<Transfer
-						onClick={() => handleOrderAgainstWarehouse9Trx(info.row)}
-						disabled={!actionOrderAgainstTrxAccess}
-					/>
-					<span>{info.getValue() as string}</span>
-				</div>
-			);
-		},
-	},
-	{
-		accessorKey: 'warehouse_10',
-		header: () => {
-			const [warehouse_name, branch_name] = getWarehouseAndBranch(warehouse, 'warehouse_10');
-			return <Location branch_name={branch_name?.slice(0, -1)} warehouse_name={warehouse_name} />;
-		},
-		enableColumnFilter: false,
-		cell: (info) => {
-			return (
-				<div className='flex items-center gap-2'>
-					<Transfer
-						onClick={() => handleOrderAgainstWarehouse10Trx(info.row)}
-						disabled={!actionOrderAgainstTrxAccess}
-					/>
-					<span>{info.getValue() as string}</span>
-				</div>
-			);
-		},
-	},
-	{
-		accessorKey: 'warehouse_11',
-		header: () => {
-			const [warehouse_name, branch_name] = getWarehouseAndBranch(warehouse, 'warehouse_11');
-			return <Location branch_name={branch_name?.slice(0, -1)} warehouse_name={warehouse_name} />;
-		},
-		enableColumnFilter: false,
-		cell: (info) => {
-			return (
-				<div className='flex items-center gap-2'>
-					<Transfer
-						onClick={() => handleOrderAgainstWarehouse11Trx(info.row)}
-						disabled={!actionOrderAgainstTrxAccess}
-					/>
-					<span>{info.getValue() as string}</span>
-				</div>
-			);
-		},
-	},
-	{
-		accessorKey: 'warehouse_12',
-		header: () => {
-			const [warehouse_name, branch_name] = getWarehouseAndBranch(warehouse, 'warehouse_12');
-			return <Location branch_name={branch_name?.slice(0, -1)} warehouse_name={warehouse_name} />;
-		},
-		enableColumnFilter: false,
-		cell: (info) => {
-			return (
-				<div className='flex items-center gap-2'>
-					<Transfer
-						onClick={() => handleOrderAgainstWarehouse12Trx(info.row)}
-						disabled={!actionOrderAgainstTrxAccess}
-					/>
-					<span>{info.getValue() as string}</span>
-				</div>
-			);
-		},
-	},
-];
+	];
+
+	const handlerMap = [
+		handleOrderAgainstWarehouse1Trx,
+		handleOrderAgainstWarehouse2Trx,
+		handleOrderAgainstWarehouse3Trx,
+		handleOrderAgainstWarehouse4Trx,
+		handleOrderAgainstWarehouse5Trx,
+		handleOrderAgainstWarehouse6Trx,
+		handleOrderAgainstWarehouse7Trx,
+		handleOrderAgainstWarehouse8Trx,
+		handleOrderAgainstWarehouse9Trx,
+		handleOrderAgainstWarehouse10Trx,
+		handleOrderAgainstWarehouse11Trx,
+		handleOrderAgainstWarehouse12Trx,
+	];
+
+	for (let i = 0; i < 12; i++) {
+		const warehouseNum = i + 1;
+		const accessorKey = `warehouse_${warehouseNum}` as const;
+		columns.push({
+			accessorKey,
+			header: () => {
+				const [warehouse_name, branch_name] = getWarehouseAndBranch(warehouse, accessorKey as IWarehouseKey);
+				return <Location branch_name={branch_name?.slice(0, -1)} warehouse_name={warehouse_name} />;
+			},
+			enableColumnFilter: false,
+			cell: (info: any) => {
+				return (
+					<div className='flex items-center gap-2'>
+						<Transfer
+							onClick={() => handlerMap[i](info.row)}
+							disabled={!actionOrderAgainstTrxAccess || info.getValue() === 0}
+						/>
+						<span>{info.getValue() as string}</span>
+					</div>
+				);
+			},
+		});
+	}
+
+	return columns;
+};
 
 //* Purchase Columns
 export const purchaseColumns = (): ColumnDef<IPurchaseTableData>[] => [

--- a/src/pages/store/_config/query/index.ts
+++ b/src/pages/store/_config/query/index.ts
@@ -267,10 +267,10 @@ export const useStoreInternalTransfersByUUID = <T>(uuid: string) =>
 	});
 
 //* Order Transfer
-export const useStoreOrderTransfers = <T>() =>
+export const useStoreOrderTransfers = <T>(query?: string) =>
 	useTQuery<T>({
-		queryKey: storeQK.orderTransfer(),
-		url: '/store/product-transfer',
+		queryKey: storeQK.orderTransfer(query),
+		url: query ? `/store/product-transfer${query}` : '/store/product-transfer',
 	});
 
 export const useStoreOrderTransfersByUUID = <T>(uuid: string) =>

--- a/src/pages/store/_config/query/queryKeys.ts
+++ b/src/pages/store/_config/query/queryKeys.ts
@@ -74,6 +74,6 @@ export const storeQK = {
 	internalTransferByUUID: (uuid: string) => [...storeQK.internalTransfer(), uuid],
 
 	//* Order Transfer
-	orderTransfer: () => [...storeQK.all(), 'orderTransfer'],
+	orderTransfer: (query?: string) => [...storeQK.all(), 'orderTransfer',query],
 	orderTransferByUUID: (uuid: string) => [...storeQK.orderTransfer(), uuid],
 };

--- a/src/pages/store/product/trx-against-order.tsx
+++ b/src/pages/store/product/trx-against-order.tsx
@@ -69,7 +69,7 @@ const Trx: React.FC<ITrxProps> = ({ url, open, setOpen, updatedData, setUpdatedD
 	}
 
 	return (
-		<AddModal open={open} setOpen={onClose} title={'Transfer Material'} form={form} onSubmit={onSubmit}>
+		<AddModal open={open} setOpen={onClose} title={'Transfer Material'} form={form} isSmall={true} onSubmit={onSubmit}>
 			<FormField
 				control={form.control}
 				name='order_uuid'

--- a/src/pages/work/_config/columns/columns.type.ts
+++ b/src/pages/work/_config/columns/columns.type.ts
@@ -33,6 +33,31 @@ export type IDiagnosisTableData = {
 	created_at: string;
 	updated_at: string;
 };
+//* Transfer
+export type ITransferTableData = {
+	uuid: string;
+	id: string;
+	warehouse_uuid: string;
+	warehouse_name: string;
+	max_quantity?: number;
+	product_name: string;
+	product_uuid: string;
+	order_id: string;
+	order_uuid: string;
+	info_uuid: string;
+	quantity: number;
+	created_at: string;
+	updated_at: string;
+	remarks: string;
+};
+//* IStockTrx
+export type IStockActionTrx = {
+	uuid: string;
+	name: string;
+	max_quantity?: number;
+	warehouse_uuid?: string;
+	product_uuid?: string;
+};
 //* Order Columns
 export type IOrderTableData = {
 	id: string;
@@ -76,6 +101,7 @@ export type IOrderTableData = {
 	created_at: string;
 	updated_at: string;
 	diagnosis?: IDiagnosisTableData;
+	product_transfer?: ITransferTableData[];
 	process?: IProcessTableData[];
 	remarks: string;
 };

--- a/src/pages/work/_config/columns/index.tsx
+++ b/src/pages/work/_config/columns/index.tsx
@@ -1,13 +1,17 @@
 import { ColumnDef, Row } from '@tanstack/react-table';
-import { MessageSquareMore, Pin, User } from 'lucide-react';
+import { values } from 'lodash';
+import { User } from 'lucide-react';
 
 import StatusButton from '@/components/buttons/status';
 import Transfer from '@/components/buttons/transfer';
+import DataTableEntry from '@/components/core/data-table/entry';
 import { CustomLink } from '@/components/others/link';
 import DateTime from '@/components/ui/date-time';
 import { Switch } from '@/components/ui/switch';
 
-import { Location, Problem, Product } from '../utils/component';
+import { cn } from '@/lib/utils';
+
+import { Location, Problem, Product, TableForColumn } from '../utils/component';
 import { LocationName, ProductName } from '../utils/function';
 import {
 	IAccessoriesTableData,
@@ -17,6 +21,7 @@ import {
 	IProblemsTableData,
 	IProcessTableData,
 	ISectionTableData,
+	ITransferTableData,
 	IZoneTableData,
 } from './columns.type';
 
@@ -537,11 +542,15 @@ export const RepairingColumns = ({
 	haveDeliveryAccess,
 	handelQCStatusChange,
 	haveQCAccess,
+	handleAgainstTrx,
+	actionTrxAccess,
 }: {
 	handelDeliveryStatusChange?: (row: Row<any>) => void;
 	haveDeliveryAccess?: boolean;
 	handelQCStatusChange?: (row: Row<any>) => void;
 	haveQCAccess?: boolean;
+	handleAgainstTrx?: (row: Row<any>) => void;
+	actionTrxAccess?: boolean;
 } = {}): ColumnDef<IOrderTableData>[] => [
 	{
 		accessorKey: 'is_transferred_for_qc',
@@ -616,6 +625,37 @@ export const RepairingColumns = ({
 					</div>
 				</div>
 			);
+		},
+	},
+	{
+		id: 'action_trx',
+		header: () => (
+			<>
+				Transfer Repairing <br />
+				Product
+			</>
+		),
+		cell: (info) => <Transfer onClick={() => handleAgainstTrx?.(info.row)} />,
+		size: 40,
+		meta: {
+			hidden: !actionTrxAccess,
+			disableFullFilter: true,
+		},
+	},
+	{
+		accessorFn: (row) => {
+			return (
+				row.product_transfer
+					?.map((item) => item?.product_name + '-' + item?.warehouse_name + '(' + item?.quantity + ')')
+					.join(', ') || ''
+			);
+		},
+		header: 'Repairing Item',
+		enableColumnFilter: false,
+		cell: (info) => {
+			const value = info.row.original.product_transfer as ITransferTableData[] | undefined;
+			const headers = ['Product', 'Warehouse', 'QTY'];
+			return <TableForColumn value={value} headers={headers} />;
 		},
 	},
 	{
@@ -762,6 +802,7 @@ export const ReadyDeliveryColumns = (): ColumnDef<IOrderTableData>[] => [
 		enableColumnFilter: false,
 		cell: (info) => info.getValue() as string,
 	},
+
 	{
 		accessorFn: (row) => LocationName(row),
 		id: 'location',
@@ -1000,6 +1041,24 @@ export const accessoriesColumns = (): ColumnDef<IAccessoriesTableData>[] => [
 	{
 		accessorKey: 'name',
 		header: 'Name',
+		enableColumnFilter: false,
+	},
+];
+//* Transfer Columns
+export const transferColumns = (): ColumnDef<ITransferTableData>[] => [
+	{
+		accessorKey: 'product_name',
+		header: 'Product',
+		enableColumnFilter: false,
+	},
+	{
+		accessorKey: 'warehouse_name',
+		header: 'Warehouse',
+		enableColumnFilter: false,
+	},
+	{
+		accessorKey: 'quantity',
+		header: 'Quantity',
 		enableColumnFilter: false,
 	},
 ];

--- a/src/pages/work/_config/query/index.ts
+++ b/src/pages/work/_config/query/index.ts
@@ -1,6 +1,9 @@
 import useTQuery from '@/hooks/useTQuery';
 
+
+
 import { workQK } from './queryKeys';
+
 
 // * Problem
 export const useWorkProblems = <T>() =>
@@ -148,5 +151,18 @@ export const useWorkAccessoriesByUUID = <T>(uuid: string) =>
 	useTQuery<T>({
 		queryKey: workQK.accessoriesByUUID(uuid),
 		url: `/work/accessory/${uuid}`,
+		enabled: !!uuid,
+	});
+//* Order Transfer
+export const useStoreOrderTransfers = <T>() =>
+	useTQuery<T>({
+		queryKey: workQK.orderTransfer(),
+		url: '/store/product-transfer',
+	});
+
+export const useStoreOrderTransfersByUUID = <T>(uuid: string) =>
+	useTQuery<T>({
+		queryKey: workQK.orderTransferByUUID(uuid),
+		url: `/store/product-transfer/${uuid}`,
 		enabled: !!uuid,
 	});

--- a/src/pages/work/_config/query/queryKeys.ts
+++ b/src/pages/work/_config/query/queryKeys.ts
@@ -1,5 +1,9 @@
 import { orderBy } from 'lodash';
 
+
+
+
+
 export const workQK = {
 	all: () => ['work'],
 
@@ -43,4 +47,7 @@ export const workQK = {
 	//* Accessories
 	accessories: () => [...workQK.all(), 'accessories'],
 	accessoriesByUUID: (uuid: string) => [...workQK.accessories(), uuid],
+	//* Order Transfer
+	orderTransfer: () => [...workQK.all(), 'orderTransfer'],
+	orderTransferByUUID: (uuid: string) => [...workQK.orderTransfer(), uuid],
 };

--- a/src/pages/work/_config/schema/index.ts
+++ b/src/pages/work/_config/schema/index.ts
@@ -261,3 +261,19 @@ export const ACCESSORIES_NULL: Partial<IAccessories> = {
 	remarks: null,
 };
 export type IAccessories = z.infer<typeof ACCESSORIES_SCHEMA>;
+//* Transfer Schema
+export const TRANSFER_SCHEMA = z.object({
+	product_uuid: STRING_REQUIRED,
+	warehouse_uuid: STRING_REQUIRED,
+	quantity: NUMBER_DOUBLE_REQUIRED,
+	remarks: STRING_NULLABLE,
+});
+
+export const TRANSFER_NULL: Partial<ITransfer> = {
+	product_uuid: '',
+	warehouse_uuid: '',
+	quantity: 0,
+	remarks: null,
+};
+
+export type ITransfer = z.infer<typeof TRANSFER_SCHEMA>;

--- a/src/pages/work/_config/utils/component.tsx
+++ b/src/pages/work/_config/utils/component.tsx
@@ -1,5 +1,7 @@
 import { Building2, Component, FileDigit, House, MapPin, MessageSquareMore, Pin, Warehouse } from 'lucide-react';
 
+import { cn } from '@/lib/utils';
+
 import { TLocationProps, TProblemProps, TProductProps } from '../types';
 
 export const Product = ({ brand_name, model_name, serial_no }: TProductProps) => {
@@ -26,7 +28,34 @@ export const Product = ({ brand_name, model_name, serial_no }: TProductProps) =>
 		</div>
 	);
 };
-
+export const TableForColumn = ({ value, headers }: any) => {
+	const rowStyle = 'border border-gray-300 px-2 py-1 text-xs';
+	return (
+		value?.length !== undefined &&
+		value?.length > 0 && (
+			<table className='border-2 border-gray-300'>
+				<thead>
+					<tr className='text-xs text-gray-600'>
+						{headers.map((header: any, idx: number) => (
+							<th key={idx} className={cn(rowStyle)}>
+								{header}
+							</th>
+						))}
+					</tr>
+				</thead>
+				<tbody>
+					{value?.map((item: any, idx: number) => (
+						<tr key={idx}>
+							<td className={cn(rowStyle)}>{item.product_name}</td>
+							<td className={cn(rowStyle)}>{item.warehouse_name}</td>
+							<td className={cn(rowStyle)}>{item.quantity}</td>
+						</tr>
+					))}
+				</tbody>
+			</table>
+		)
+	);
+};
 export const Problem = ({ problem_statement, problems_name }: TProblemProps) => {
 	return (
 		<div className='flex flex-col gap-2'>

--- a/src/pages/work/diagonsis/index.tsx
+++ b/src/pages/work/diagonsis/index.tsx
@@ -71,7 +71,7 @@ const Diagnosis = () => {
 				handleUpdate={handleUpdate}
 				handleDelete={handleDelete}
 				handleRefetch={refetch}
-				defaultVisibleColumns={{ updated_at: false, created_by_name: false }}
+				defaultVisibleColumns={{ updated_at: false, created_at: false, created_by_name: false }}
 			>
 				{renderSuspenseModals([
 					<AddOrUpdate

--- a/src/pages/work/is-ready-deliver/index.tsx
+++ b/src/pages/work/is-ready-deliver/index.tsx
@@ -62,7 +62,7 @@ const Order = () => {
 				handleUpdate={handleUpdate}
 				handleDelete={handleDelete}
 				handleRefetch={refetch}
-				defaultVisibleColumns={{ updated_at: false, created_by_name: false }}
+				defaultVisibleColumns={{ updated_at: false, created_at: false, created_by_name: false }}
 			>
 				{renderSuspenseModals([
 					<AddOrUpdate

--- a/src/pages/work/order/add-or-update.tsx
+++ b/src/pages/work/order/add-or-update.tsx
@@ -44,6 +44,7 @@ const AddOrUpdate: React.FC<IOrderAddOrUpdateProps> = ({
 	const { data: boxOption } = useOtherBox<IFormSelectOption[]>();
 	const { data: brandOptions } = useOtherBrand<IFormSelectOption[]>();
 	const { invalidateQuery: invalidateDiagnosis } = useWorkDiagnosis<IDiagnosisTableData[]>();
+	
 
 	const form = useRHF(ORDER_SCHEMA, ORDER_NULL);
 	const { data: modelOption, invalidateQuery: invalidateModel } = useOtherModelByQuery<IFormSelectOption[]>(

--- a/src/pages/work/order/details/index.tsx
+++ b/src/pages/work/order/details/index.tsx
@@ -6,12 +6,11 @@ import { IOrderTableData } from '../../_config/columns/columns.type';
 import { useWorkOrderByDetails } from '../../_config/query';
 import Information from './information';
 import EntryTable from './process';
+import Transfer from './transfer';
 
 const DetailsPage = () => {
 	const { uuid } = useParams();
 	const { data, isLoading, updateData } = useWorkOrderByDetails<IOrderTableData>(uuid as string);
-
-
 
 	useEffect(() => {
 		document.title = 'Order Details';
@@ -22,6 +21,9 @@ const DetailsPage = () => {
 	return (
 		<div className='space-y-8'>
 			<Information data={(data || []) as IOrderTableData} updateData={updateData} />
+			{data?.is_proceed_to_repair && (
+				<Transfer data={(data || []) as IOrderTableData} isLoading={isLoading} order_uuid={data?.uuid} />
+			)}
 			{data?.is_proceed_to_repair && <EntryTable data={(data || []) as IOrderTableData} isLoading={isLoading} />}
 		</div>
 	);

--- a/src/pages/work/order/details/process/index.tsx
+++ b/src/pages/work/order/details/process/index.tsx
@@ -17,8 +17,8 @@ const EntryTable: React.FC<{ data?: IOrderTableData; isLoading?: any }> = ({ dat
 	const navigate = useNavigate();
 	const { url, deleteData, postData, updateData, refetch } = useWorkProcesses<IProcessTableData[]>();
 
-	const pageInfo = useMemo(() => new PageInfo('Work/Process', url, 'work__process'), [url]);
-	const diagnosis_uuid = data?.is_diagnosis_need ? data?.diagnosis?.uuid : 'null';
+	const pageInfo = useMemo(() => new PageInfo('Process', url, 'work__process'), [url]);
+
 
 	// Add/Update Modal state
 	const [isOpenAddModal, setIsOpenAddModal] = useState(false);

--- a/src/pages/work/order/details/transfer/add-or-update.tsx
+++ b/src/pages/work/order/details/transfer/add-or-update.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useState } from 'react';
+import { IResponse } from '@/types';
+import { UseMutationResult } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { z } from 'zod';
+import useAuth from '@/hooks/useAuth';
+import useRHF from '@/hooks/useRHF';
+
+import { IFormSelectOption } from '@/components/core/form/types';
+import { FormField } from '@/components/ui/form';
+import CoreForm from '@core/form';
+import { AddModal } from '@core/modal';
+
+import { useOtherOrder, useOtherProduct, useOtherWarehouse } from '@/lib/common-queries/other';
+import nanoid from '@/lib/nanoid';
+import { getDateTime } from '@/utils';
+
+import { IOrderTableData, IStockActionTrx, ITransferTableData } from '../../../_config/columns/columns.type';
+import { useStoreOrderTransfersByUUID, useWorkOrderByDetails } from '../../../_config/query';
+import { TRANSFER_NULL, TRANSFER_SCHEMA } from '../../../_config/schema';
+import { getFilteredWarehouseOptions, ICustomProductsSelectOption, ICustomWarehouseSelectOption } from './utills';
+
+interface ITrxProps {
+	url: string;
+	open: boolean;
+	setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+	updatedData?: IStockActionTrx | null;
+	setUpdatedData?: React.Dispatch<React.SetStateAction<IStockActionTrx | null>>;
+	order_uuid?: string;
+	postData: UseMutationResult<
+		IResponse<any>,
+		AxiosError<IResponse<any>, any>,
+		{
+			url: string;
+			newData: any;
+			isOnCloseNeeded?: boolean;
+			onClose?: (() => void) | undefined;
+		},
+		any
+	>;
+	updateData: UseMutationResult<
+		IResponse<any>,
+		AxiosError<IResponse<any>, any>,
+		{
+			url: string;
+			updatedData: any;
+			isOnCloseNeeded?: boolean;
+			onClose?: (() => void) | undefined;
+		},
+		any
+	>;
+}
+
+const Trx: React.FC<ITrxProps> = ({
+	url,
+	open,
+	setOpen,
+	updatedData,
+	setUpdatedData,
+	updateData,
+	postData,
+	order_uuid,
+}) => {
+	const isUpdate = !!updatedData;
+
+	const { data } = useStoreOrderTransfersByUUID<ITransferTableData>(updatedData?.uuid as string);
+	const { data: productOptions } = useOtherProduct<ICustomProductsSelectOption[]>();
+	const { data: warehouseOptions } = useOtherWarehouse<ICustomWarehouseSelectOption[]>();
+	const { invalidateQuery: invalidateQueryOrderByDetails } = useWorkOrderByDetails<IOrderTableData>(
+		order_uuid as string
+	);
+
+	const { user } = useAuth();
+	const [MAX_QUANTITY, setMAX_QUANTITY] = useState(0);
+	const schema = TRANSFER_SCHEMA.extend({ quantity: z.number().int().positive().max(MAX_QUANTITY) });
+	const form = useRHF(schema, TRANSFER_NULL);
+
+	const filteredWarehouseOptions = getFilteredWarehouseOptions(
+		form.watch('product_uuid'),
+		productOptions,
+		warehouseOptions
+	);
+
+	//* Set Max Quantity
+	const product_uuid = form.watch('product_uuid');
+	const warehouse_uuid = form.watch('warehouse_uuid');
+	useEffect(() => {
+		if (product_uuid && warehouse_uuid && productOptions) {
+			const selectedProduct = productOptions.find((p) => p.value === product_uuid);
+			const selectedWarehouse = warehouseOptions?.find((w) => w.value === warehouse_uuid);
+
+			if (selectedProduct && selectedWarehouse) {
+				const warehouseKey = selectedWarehouse.assigned;
+				const quantity = (selectedProduct[warehouseKey as keyof ICustomProductsSelectOption] as number) || 0;
+				setMAX_QUANTITY(quantity);
+			} else {
+				setMAX_QUANTITY(0);
+			}
+		} else {
+			setMAX_QUANTITY(0);
+		}
+	}, [product_uuid, warehouse_uuid, productOptions, warehouseOptions]);
+
+	const onClose = () => {
+		setUpdatedData?.(null);
+		form.reset(TRANSFER_NULL);
+		setOpen((prev) => !prev);
+		invalidateQueryOrderByDetails();
+	};
+	useEffect(() => {
+		if (data && isUpdate) {
+			form.reset(data);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [data, isUpdate]);
+	// Submit handler
+	async function onSubmit(values: IStockActionTrx) {
+		if (isUpdate) {
+			// ADD NEW ITEM
+			updateData.mutateAsync({
+				url: `${url}/${updatedData?.uuid}`,
+				updatedData: {
+					...values,
+					order_uuid: order_uuid,
+					created_at: getDateTime(),
+					created_by: user?.uuid,
+					uuid: nanoid(),
+				},
+				onClose,
+			});
+		} else {
+			await postData.mutateAsync({
+				url,
+				newData: {
+					...values,
+					order_uuid: order_uuid,
+					created_at: getDateTime(),
+					created_by: user?.uuid,
+					uuid: nanoid(),
+				},
+				onClose,
+			});
+		}
+	}
+
+	return (
+		<AddModal open={open} setOpen={onClose} title={'Transfer Material'} form={form} onSubmit={onSubmit}>
+			<FormField
+				control={form.control}
+				name='product_uuid'
+				render={(props) => (
+					<CoreForm.ReactSelect
+						label='Product'
+						placeholder='Select Order'
+						options={productOptions!}
+						{...props}
+					/>
+				)}
+			/>
+			<FormField
+				control={form.control}
+				name='warehouse_uuid'
+				render={(props) => (
+					<CoreForm.ReactSelect
+						label='Warehouse'
+						placeholder='Select Order'
+						options={filteredWarehouseOptions!}
+						{...props}
+					/>
+				)}
+			/>
+			<FormField
+				control={form.control}
+				name='quantity'
+				render={(props) => (
+					<CoreForm.Input label={`Quantity (Max Transfer: ${MAX_QUANTITY})`} type='number' {...props} />
+				)}
+			/>
+			<FormField control={form.control} name='remarks' render={(props) => <CoreForm.Textarea {...props} />} />
+		</AddModal>
+	);
+};
+
+export default Trx;

--- a/src/pages/work/order/details/transfer/index.tsx
+++ b/src/pages/work/order/details/transfer/index.tsx
@@ -1,0 +1,128 @@
+import { lazy, useMemo, useState } from 'react';
+import { PageProvider, TableProvider } from '@/context';
+import { transferColumns } from '../../../_config/columns';
+import { IStockActionTrx, ITransferTableData } from '@/pages/store/_config/columns/columns.type';
+import { useStoreOrderTransfers } from '@/pages/store/_config/query';
+import { IOrderTableData } from '@/pages/work/_config/columns/columns.type';
+import { Row } from '@tanstack/react-table';
+
+import { PageInfo } from '@/utils';
+import renderSuspenseModals from '@/utils/renderSuspenseModals';
+
+const AddOrUpdate = lazy(() => import('./add-or-update'));
+const DeleteModal = lazy(() => import('@core/modal/delete'));
+const DeleteAllModal = lazy(() => import('@core/modal/delete/all'));
+
+const Transfer: React.FC<{ data?: IOrderTableData; isLoading?: any; order_uuid?: string }> = ({
+	data,
+	isLoading,
+	order_uuid,
+}) => {
+	const { url, deleteData, postData, updateData, refetch } = useStoreOrderTransfers<ITransferTableData[]>();
+
+	const pageInfo = useMemo(() => new PageInfo('Repairing Item', url, 'work__process'), [url]);
+
+	// Add/Update Modal state
+	const [isOpenAddModal, setIsOpenAddModal] = useState(false);
+
+	const [updatedData, setUpdatedData] = useState<IStockActionTrx | null>(null);
+
+	const handleUpdate = (row: Row<ITransferTableData>) => {
+		setUpdatedData({
+			uuid: row.original.uuid,
+			name: row.original.order_id,
+			max_quantity: row.original.max_quantity,
+			product_uuid: row.original.product_uuid,
+			warehouse_uuid: row.original.warehouse_uuid,
+		});
+
+		setIsOpenAddModal(true);
+	};
+	const handleCreate = () => {
+		setIsOpenAddModal(true);
+	};
+	// Delete Modal state
+	// Single Delete Item
+	const [deleteItem, setDeleteItem] = useState<{
+		id: string;
+		name: string;
+	} | null>(null);
+
+	// Single Delete Handler
+	const handleDelete = (row: Row<ITransferTableData>) => {
+		setDeleteItem({
+			id: row?.original?.uuid,
+			name: row?.original?.order_id,
+		});
+	};
+
+	// Delete All Item
+	const [deleteItems, setDeleteItems] = useState<{ id: string; name: string; checked: boolean }[] | null>(null);
+
+	// Delete All Row Handlers
+	const handleDeleteAll = (rows: Row<ITransferTableData>[]) => {
+		const selectedRows = rows.map((row) => row.original);
+
+		setDeleteItems(
+			selectedRows.map((row) => ({
+				id: row.uuid,
+				name: row.order_id,
+				checked: true,
+			}))
+		);
+	};
+
+	// Table Columns
+	const columns = transferColumns();
+
+	return (
+		<PageProvider pageName={pageInfo.getTab()} pageTitle={pageInfo.getTabName()}>
+			<TableProvider
+				title={pageInfo.getTitle()}
+				columns={columns}
+				data={data?.product_transfer ?? []}
+				isLoading={isLoading}
+				handleUpdate={handleUpdate}
+				handleDelete={handleDelete}
+				handleCreate={handleCreate}
+				handleRefetch={refetch}
+				handleDeleteAll={handleDeleteAll}
+				defaultVisibleColumns={{ updated_at: false, created_at: false, created_by_name: false }}
+			>
+				{renderSuspenseModals([
+					<AddOrUpdate
+						{...{
+							url,
+							open: isOpenAddModal,
+							setOpen: setIsOpenAddModal,
+							updatedData,
+							setUpdatedData,
+							updateData,
+							postData,
+							order_uuid: order_uuid ?? '',
+						}}
+					/>,
+
+					<DeleteModal
+						{...{
+							deleteItem,
+							setDeleteItem,
+							url,
+							deleteData,
+						}}
+					/>,
+					<DeleteAllModal
+						{...{
+							deleteItems,
+							setDeleteItems,
+							url,
+							deleteData,
+						}}
+					/>,
+				])}
+			</TableProvider>
+		</PageProvider>
+	);
+};
+
+export default Transfer;

--- a/src/pages/work/order/details/transfer/utills.ts
+++ b/src/pages/work/order/details/transfer/utills.ts
@@ -1,0 +1,36 @@
+import { IFormSelectOption } from '@/components/core/form/types';
+
+export interface ICustomProductsSelectOption extends IFormSelectOption {
+	
+	warehouse_1: number;
+	warehouse_2: number;
+	warehouse_3: number;
+	warehouse_4: number;
+	warehouse_5: number;
+	warehouse_6: number;
+	warehouse_7: number;
+	warehouse_8: number;
+	warehouse_9: number;
+	warehouse_10: number;
+	warehouse_11: number;
+	warehouse_12: number;
+
+}
+export interface ICustomWarehouseSelectOption extends IFormSelectOption {
+	assigned: string;
+}
+
+export function getFilteredWarehouseOptions(
+	productUuid: string,
+	productOptions: ICustomProductsSelectOption[] = [],
+	warehouseOptions: ICustomWarehouseSelectOption[] = []
+) {
+	const selectedProduct = productOptions.find((p) => p.value === productUuid);
+	if (!selectedProduct) return [];
+
+	const availableWarehouses = Object.keys(selectedProduct).filter(
+		(key) => key.startsWith('warehouse_') && (selectedProduct as any)[key] > 0
+	);
+
+	return warehouseOptions.filter((wo) => availableWarehouses.includes(wo.assigned));
+}

--- a/src/pages/work/qc/index.tsx
+++ b/src/pages/work/qc/index.tsx
@@ -55,7 +55,7 @@ const Order = () => {
 				handleCreate={handleCreate}
 				handleUpdate={handleUpdate}
 				handleRefetch={refetch}
-				defaultVisibleColumns={{ updated_at: false, created_by_name: false }}
+				defaultVisibleColumns={{ updated_at: false, created_at: false, created_by_name: false }}
 			>
 				{renderSuspenseModals([
 					<AddOrUpdate

--- a/src/pages/work/repairing/index.tsx
+++ b/src/pages/work/repairing/index.tsx
@@ -10,6 +10,8 @@ import { RepairingColumns } from '../_config/columns';
 import { IOrderTableData } from '../_config/columns/columns.type';
 import { useWorkRepairing } from '../_config/query';
 
+const OrderTransferModal = lazy(() => import('../order/details/transfer/add-or-update'));
+
 const AddOrUpdate = lazy(() => import('./add-or-update'));
 
 const Order = () => {
@@ -19,9 +21,12 @@ const Order = () => {
 	const pageAccess = useAccess('work__repairing') as string[];
 	const haveDeliveryAccess = pageAccess?.includes('click_transfer_delivery');
 	const haveQCAccess = pageAccess?.includes('click_transfer_qc');
+	const actionTrxAccess = pageAccess?.includes('click_order_transfer');
 
 	// Add/Update Modal state
 	const [isOpenAddModal, setIsOpenAddModal] = useState(false);
+	const [isTrxOpenAddModal, setIsTrxOpenAddModal] = useState(false);
+	const [order_uuid, setOrderUuid] = useState('');
 
 	const handleCreate = () => {
 		setIsOpenAddModal(true);
@@ -32,6 +37,11 @@ const Order = () => {
 	const handleUpdate = (row: Row<IOrderTableData>) => {
 		setUpdatedData(row.original);
 		setIsOpenAddModal(true);
+	};
+	const handleAgainstTrx = (row: Row<IOrderTableData>) => {
+		setUpdatedData(row.original);
+		setIsTrxOpenAddModal(true);
+		setOrderUuid(row.original.uuid);
 	};
 
 	// Table Columns
@@ -55,11 +65,14 @@ const Order = () => {
 			isOnCloseNeeded: false,
 		});
 	};
+
 	const columns = RepairingColumns({
 		handelDeliveryStatusChange,
 		haveDeliveryAccess,
 		handelQCStatusChange,
 		haveQCAccess,
+		handleAgainstTrx,
+		actionTrxAccess,
 	});
 
 	return (
@@ -72,7 +85,7 @@ const Order = () => {
 				handleCreate={handleCreate}
 				handleUpdate={handleUpdate}
 				handleRefetch={refetch}
-				defaultVisibleColumns={{ updated_at: false, created_by_name: false }}
+				defaultVisibleColumns={{ updated_at: false, created_at: false, created_by_name: false }}
 			>
 				{renderSuspenseModals([
 					<AddOrUpdate
@@ -84,6 +97,16 @@ const Order = () => {
 							setUpdatedData,
 							postData,
 							updateData,
+						}}
+					/>,
+					<OrderTransferModal
+						{...{
+							open: isTrxOpenAddModal,
+							setOpen: setIsTrxOpenAddModal,
+							url: '/store/product-transfer',
+							postData,
+							updateData,
+							order_uuid,
 						}}
 					/>,
 				])}

--- a/src/routes/private/work.tsx
+++ b/src/routes/private/work.tsx
@@ -88,7 +88,7 @@ const workRoutes: IRoute[] = [
 				path: '/work/repairing',
 				element: <Repairing />,
 				page_name: 'work__repairing',
-				actions: ['read', 'update', 'click_transfer_qc', 'click_transfer_delivery'],
+				actions: ['read', 'update', 'click_transfer_qc', 'click_transfer_delivery', 'click_order_transfer'],
 			},
 			{
 				name: 'QC',


### PR DESCRIPTION
- Implemented display of repairing items in the order details page
- Added repairing item transfer feature and display as table to the orders index page

## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

Fixes # (issue)

## Screenshots (if appropriate):

<!-- If not applicable, delete this section. -->

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I ran `npm run lint` and my changes did not introduce any lint or formatting errors.
-   [ ] I ran `npm run build` and tested the distribution build.
