### PR TITLE
Fix validation and UI for joining amount and salary fields

### DIFF
--- a/src/pages/hr/employee/_config/schema/index.ts
+++ b/src/pages/hr/employee/_config/schema/index.ts
@@ -5,6 +5,7 @@ import {
 	GENDER,
 	NUMBER_DOUBLE,
 	NUMBER_DOUBLE_OPTIONAL,
+	NUMBER_DOUBLE_REQUIRED,
 	PASSWORD,
 	STRING_NULLABLE,
 	STRING_OPTIONAL,
@@ -28,7 +29,7 @@ export const EMPLOYEE_SCHEMA = z.object({
 	leave_policy_uuid: STRING_NULLABLE,
 	employment_type_uuid: STRING_NULLABLE,
 	shift_group_uuid: STRING_NULLABLE,
-		joining_amount: NUMBER_DOUBLE_OPTIONAL,
+	joining_amount: NUMBER_DOUBLE_REQUIRED.min(1, 'Joining amount must be greater than 0'),
 });
 
 export const EMPLOYEE_NULL: Partial<IEmployee> = {

--- a/src/pages/hr/employee/add-or-update.tsx
+++ b/src/pages/hr/employee/add-or-update.tsx
@@ -120,6 +120,13 @@ const AddOrUpdate: React.FC<IEmployeeAddOrUpdateProps> = ({
 				/>
 
 				<FormField control={form.control} name='gender' render={(props) => <CoreForm.Gender {...props} />} />
+				<FormField
+					control={form.control}
+					name='joining_amount'
+					render={(props) => (
+						<CoreForm.JoinInputUnit unit='Tk' type='number' label='Joining Amount' {...props} />
+					)}
+				/>
 			</div>
 
 			<Accordion type='single' collapsible>
@@ -217,13 +224,6 @@ const AddOrUpdate: React.FC<IEmployeeAddOrUpdateProps> = ({
 								name='shift_group_uuid'
 								render={(props) => (
 									<CoreForm.Select label='Shift Group' options={shiftGroups || []} {...props} />
-								)}
-							/>
-							<FormField
-								control={form.control}
-								name='joining_amount'
-								render={(props) => (
-									<CoreForm.JoinInputUnit unit='Tk' type='number' label='Joining Amount' {...props} />
 								)}
 							/>
 						</div>

--- a/src/pages/payroll/_config/schema/index.ts
+++ b/src/pages/payroll/_config/schema/index.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import {
 	BOOLEAN_REQUIRED,
+	NUMBER_DOUBLE_OPTIONAL,
 	NUMBER_DOUBLE_REQUIRED,
 	NUMBER_REQUIRED,
 	STRING_NULLABLE,
@@ -18,6 +19,8 @@ export const SALARY_SCHEMA = z.object({
 	year: NUMBER_REQUIRED.min(1900, { message: 'Year must be 1900 or later' }).max(new Date().getFullYear(), {
 		message: `Year can't be in the future`,
 	}),
+	loan_amount: NUMBER_DOUBLE_OPTIONAL,
+	advance_amount: NUMBER_DOUBLE_OPTIONAL,
 });
 
 export const SALARY_NULL: Partial<ISalary> = {
@@ -26,6 +29,8 @@ export const SALARY_NULL: Partial<ISalary> = {
 	amount: 0,
 	month: 0,
 	year: 0,
+	loan_amount: 0,
+	advance_amount: 0,
 };
 
 export type ISalary = z.infer<typeof SALARY_SCHEMA>;

--- a/src/pages/payroll/monthly-details/details/calcInfo.tsx
+++ b/src/pages/payroll/monthly-details/details/calcInfo.tsx
@@ -56,9 +56,7 @@ const CalcInfo: React.FC<{ data: IMonthlyDetailsTableData }> = ({ data }) => {
 
 			<Card className='w-96 overflow-hidden shadow-sm'>
 				<CardContent className='p-4'>
-					<h2 className='mb-3 flex justify-between rounded-md px-2 py-1 font-semibold'>
-						Calculation Information
-					</h2>
+					<h2 className='mb-3 flex justify-between rounded-md px-2 py-1 font-semibold'>Net Payable</h2>
 
 					<div className='text-sm'>
 						<p className='flex justify-between rounded-md px-2 py-1'>

--- a/src/pages/payroll/salary/add-or-update.tsx
+++ b/src/pages/payroll/salary/add-or-update.tsx
@@ -105,6 +105,25 @@ const AddOrUpdate: React.FC<IAddOrUpdateProps<ISalaryTableData>> = ({
 				name='amount'
 				render={(props) => <CoreForm.JoinInputUnit unit='Tk.' type='number' label='amount' {...props} />}
 			/>
+
+			{form.watch('type') === 'partial' && (
+				<>
+					<FormField
+						control={form.control}
+						name='loan_amount'
+						render={(props) => (
+							<CoreForm.JoinInputUnit unit='Tk.' type='number' label='Loan Amount' {...props} />
+						)}
+					/>
+					<FormField
+						control={form.control}
+						name='advance_amount'
+						render={(props) => (
+							<CoreForm.JoinInputUnit unit='Tk.' type='number' label='Advance Amount' {...props} />
+						)}
+					/>
+				</>
+			)}
 			<FormField
 				control={form.control}
 				name='year'


### PR DESCRIPTION
Update the joining amount field to be required and ensure proper validation. Add loan and advance amount fields to the salary schema and UI. Adjust the display title in the calculation information section.