### PR TITLE
Refactor ITransferTableData structure and related components

### DIFF
--- a/src/pages/store/_config/columns/columns.type.ts
+++ b/src/pages/store/_config/columns/columns.type.ts
@@ -220,8 +220,8 @@ export type ITransferTableData = {
 	id: string;
 	warehouse_uuid: string;
 	warehouse_name: string;
-	branch_uuid: string;
-	branch_name: string;
+	branch_uuid?: string;
+	branch_name?: string;
 	max_quantity?: number;
 	product_name: string;
 	product_uuid: string;

--- a/src/pages/store/_config/columns/index.tsx
+++ b/src/pages/store/_config/columns/index.tsx
@@ -371,7 +371,14 @@ export const purchaseEntryColumns = (): ColumnDef<IPurchaseEntryTableData>[] => 
 		),
 	},
 	{
-		accessorFn: (row) => LocationName(row),
+		accessorFn: (row) =>
+			LocationName({
+				branch_name: row.branch_name ?? '',
+				warehouse_name: row.warehouse_name ?? '',
+				rack_name: row.rack_name ?? '',
+				floor_name: row.floor_name ?? '',
+				box_name: row.box_name ?? '',
+			}),
 		id: 'location',
 		header: 'Location',
 		enableColumnFilter: false,
@@ -580,7 +587,7 @@ export const internalTransferColumns = (): ColumnDef<IInternalTransferTableData>
 	},
 ];
 //* Transfer Columns
-export const transferColumns = (): ColumnDef<ITransferTableData>[] => [
+export const transferColumns = (): ColumnDef<ITransferTableData, unknown>[] => [
 	{
 		accessorKey: 'order_id',
 		header: 'ID',
@@ -619,19 +626,18 @@ export const transferColumns = (): ColumnDef<ITransferTableData>[] => [
 		enableColumnFilter: false,
 	},
 	{
-		accessorFn: (row) => LocationName(row),
+		accessorFn: (row) =>
+			LocationName({
+				branch_name: row.branch_name ?? '',
+				warehouse_name: row.warehouse_name ?? '',
+			}),
 		id: 'location',
 		header: 'Location',
 		enableColumnFilter: false,
 		size: 170,
 		cell: (info) => {
 			const { branch_name, warehouse_name } = info.row.original;
-			return (
-				<Location
-					branch_name={branch_name}
-					warehouse_name={warehouse_name}
-				/>
-			);
+			return <Location branch_name={branch_name!} warehouse_name={warehouse_name} />;
 		},
 	},
 ];

--- a/src/pages/work/_config/columns/columns.type.ts
+++ b/src/pages/work/_config/columns/columns.type.ts
@@ -123,11 +123,9 @@ export type IOrderTableData = {
 	product_transfer?: ITransferTableData[];
 	process?: IProcessTableData[];
 	remarks: string;
-
 	image_1?: string;
 	image_2?: string;
 	image_3?: string;
-
 	status_update_date: string;
 	status: string;
 	diagnosis_proposed_cost: number;

--- a/src/pages/work/_config/columns/index.tsx
+++ b/src/pages/work/_config/columns/index.tsx
@@ -1,8 +1,6 @@
 import { ColumnDef, Row } from '@tanstack/react-table';
 import { User } from 'lucide-react';
 
-
-
 import StatusButton from '@/components/buttons/status';
 import Transfer from '@/components/buttons/transfer';
 import ColumnImage from '@/components/core/data-table/_views/column-image';
@@ -10,12 +8,19 @@ import { CustomLink } from '@/components/others/link';
 import DateTime from '@/components/ui/date-time';
 import { Switch } from '@/components/ui/switch';
 
-
-
 import { Location, Problem, Product, TableForColumn, UserNamePhone } from '../utils/component';
 import { LocationName, ProductName } from '../utils/function';
-import { IAccessoriesTableData, IDiagnosisTableData, IInfoTableData, IOrderTableData, IProblemsTableData, IProcessTableData, ISectionTableData, ITransferTableData, IZoneTableData } from './columns.type';
-
+import {
+	IAccessoriesTableData,
+	IDiagnosisTableData,
+	IInfoTableData,
+	IOrderTableData,
+	IProblemsTableData,
+	IProcessTableData,
+	ISectionTableData,
+	ITransferTableData,
+	IZoneTableData,
+} from './columns.type';
 
 //* Problems Columns
 export const problemsColumns = (): ColumnDef<IProblemsTableData>[] => [
@@ -873,7 +878,7 @@ export const RepairingColumns = ({
 		enableColumnFilter: false,
 		cell: (info) => {
 			const value = info.row.original.product_transfer as ITransferTableData[] | undefined;
-			const headers = ['Product', 'Serial','Branch' ,'Warehouse'];
+			const headers = ['Product', 'Serial', 'Branch', 'Warehouse'];
 			return <TableForColumn value={value} headers={headers} />;
 		},
 	},
@@ -1392,7 +1397,7 @@ export const accessoriesColumns = (): ColumnDef<IAccessoriesTableData>[] => [
 	},
 ];
 //* Transfer Columns
-export const transferColumns = (): ColumnDef<ITransferTableData>[] => [
+export const transferColumns = (): ColumnDef<ITransferTableData, unknown>[] => [
 	{
 		accessorKey: 'product_name',
 		header: 'Product',

--- a/src/pages/work/order/details/transfer/index.tsx
+++ b/src/pages/work/order/details/transfer/index.tsx
@@ -8,7 +8,8 @@ import { Row } from '@tanstack/react-table';
 import { PageInfo } from '@/utils';
 import renderSuspenseModals from '@/utils/renderSuspenseModals';
 
-import { transferColumns } from '../../../_config/columns';
+// Ensure transferColumns uses the correct ITransferTableData type from store/_config/columns/columns.type
+import { transferColumns } from '@/pages/store/_config/columns';
 
 const AddOrUpdate = lazy(() => import('./add-or-update'));
 const DeleteModal = lazy(() => import('@core/modal/delete'));

--- a/src/pages/work/order/index.tsx
+++ b/src/pages/work/order/index.tsx
@@ -25,7 +25,8 @@ const Order = () => {
 	const actionTrxAccess = pageAccess.includes('click_trx');
 	const actionProceedToRepair = pageAccess.includes('click_proceed_to_repair');
 	const actionDiagnosisNeed = pageAccess.includes('click_diagnosis_need');
-	const { data, isLoading, url, deleteData, postData, updateData, refetch } = useWorkInHandWork<IOrderTableData[]>();
+	const { data, isLoading, url, deleteData, postData, imageUpdateData, updateData, refetch } =
+		useWorkInHandWork<IOrderTableData[]>();
 
 	const pageInfo = useMemo(() => new PageInfo('Work/Order', url, 'work__order'), [url]);
 
@@ -62,7 +63,7 @@ const Order = () => {
 		const is_proceed_to_repair = !row?.original?.is_proceed_to_repair;
 		const updated_at = getDateTime();
 
-		await updateData.mutateAsync({
+		await imageUpdateData.mutateAsync({
 			url: `/work/order/${row?.original?.uuid}`,
 			updatedData: { is_proceed_to_repair, updated_at },
 		});
@@ -73,7 +74,7 @@ const Order = () => {
 		const is_diagnosis_need = !row?.original?.is_diagnosis_need;
 		const updated_at = getDateTime();
 
-		await updateData.mutateAsync({
+		await imageUpdateData.mutateAsync({
 			url: `/work/order/${row?.original?.uuid}`,
 			updatedData: { is_diagnosis_need, updated_at },
 		});


### PR DESCRIPTION
Make `branch_uuid` and `branch_name` optional in `ITransferTableData`, and update related components to accommodate the new structure. Adjust column definitions and data handling accordingly.